### PR TITLE
Prevent recursive loop when NXDOMAIN

### DIFF
--- a/etc/godns.conf
+++ b/etc/godns.conf
@@ -15,7 +15,7 @@ port = 5321
 # Domain-specific nameservers configuration, formatting keep compatible with Dnsmasq
 # Semicolon separate multiple files.
 server-list-file = "./etc/apple.china.conf;./etc/google.china.conf"
-resolv-file = "/etc/resolv.conf"
+resolv-file = "./etc/resolv.conf"
 timeout = 5  # 5 seconds
 # The concurrency interval request upstream recursive server
 # Match the PR15, https://github.com/kenshinx/godns/pull/15

--- a/etc/resolv.conf
+++ b/etc/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 1.1.1.1
+nameserver 1.0.0.1


### PR DESCRIPTION
When the answer is NXDOMAIN, GoDNS tries to reach upstream. Upstream was configured with the local dnsmasq which forwards the request back to GoDNS as it's a domain name in *.scalingo.dbs.test. And here is a infinite loop. I updated the upstream server to be Cloudflare DNS which will definitely return NXDOMAIN for such resquests