### PR TITLE
Revert "Revert "Prevent recursive loop when NXDOMAIN""

### DIFF
--- a/etc/godns.conf
+++ b/etc/godns.conf
@@ -15,7 +15,7 @@ port = 5321
 # Domain-specific nameservers configuration, formatting keep compatible with Dnsmasq
 # Semicolon separate multiple files.
 server-list-file = "./etc/apple.china.conf;./etc/google.china.conf"
-resolv-file = "/etc/resolv.conf"
+resolv-file = "./etc/resolv.conf"
 timeout = 5  # 5 seconds
 # The concurrency interval request upstream recursive server
 # Match the PR15, https://github.com/kenshinx/godns/pull/15

--- a/etc/resolv.conf
+++ b/etc/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 1.1.1.1
+nameserver 1.0.0.1


### PR DESCRIPTION
Reverts Scalingo/godns#3

Nobody remembers what the PR #3 was about. But it definitely breaks the dev env. Let's revert it :) 